### PR TITLE
Lock protowhat to update shared image

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -72,7 +72,7 @@ echo 'solutions directory'
 ls -lR /solutions
 
 echo 'locking protowhat'
-pip install git+https://github.com/datacamp/protowhat.git@v1.14.1 --target /var/lib/python/site-packages
+pip install git+https://github.com/datacamp/protowhat.git@v1.14.1 --target /usr/local/lib/python3.5/dist-packages
 
 # Report end of installation.
 echo

--- a/requirements.sh
+++ b/requirements.sh
@@ -72,7 +72,7 @@ echo 'solutions directory'
 ls -lR /solutions
 
 echo 'locking protowhat'
-pip install git+https://github.com/datacamp/protowhat.git@v1.14.1 --target /var/lib/python/site-packages
+pip install git+https://github.com/datacamp/protowhat.git@v1.8.0 --target /usr/local/lib/python3.5/dist-packages
 
 # Report end of installation.
 echo

--- a/requirements.sh
+++ b/requirements.sh
@@ -71,6 +71,9 @@ ls -R ${HOME_COPY}
 echo 'solutions directory'
 ls -lR /solutions
 
+echo 'locking protowhat'
+pip install git+https://github.com/datacamp/protowhat.git@v1.14.1 --target /var/lib/python/site-packages
+
 # Report end of installation.
 echo
 echo 'ENDING requirements.sh'

--- a/requirements.sh
+++ b/requirements.sh
@@ -72,7 +72,7 @@ echo 'solutions directory'
 ls -lR /solutions
 
 echo 'locking protowhat'
-pip install git+https://github.com/datacamp/protowhat.git@v1.14.1 --target /usr/local/lib/python3.5/dist-packages
+pip install git+https://github.com/datacamp/protowhat.git@v1.14.1 --target /var/lib/python/site-packages
 
 # Report end of installation.
 echo


### PR DESCRIPTION
This PR install protowhat through the requirements file.
Once this PR is merged into master, the shell shared image can be updated to its newest version in which the has_dir incorrect_msg argument is renamed to msg. (Which is a problem for example in ex1.11 step 3)
In a single PR I can then rename this argument and remove the protowhat installation.
This way the course works at all times.